### PR TITLE
onPing listener

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -51,6 +51,10 @@ int main()
             }*/
         });
 
+        worker.onPing([](WebSocket webSocket, char *message, size_t length) {
+            cout << "Got a ping!" << endl;
+        });
+
         worker.onPong([](WebSocket webSocket, char *message, size_t length) {
             cout << "Got a pong!" << endl;
         });

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -130,6 +130,7 @@ Server::Server(int port, bool master, int options, int maxPayload) : master(mast
     onConnection([](WebSocket webSocket) {});
     onDisconnection([](WebSocket webSocket, int code, char *message, size_t length) {});
     onMessage([](WebSocket webSocket, char *message, size_t length, OpCode opCode) {});
+    onPing([](WebSocket webSocket, char *message, size_t length) {});
     onPong([](WebSocket webSocket, char *message, size_t length) {});
     onUpgrade([this](uv_os_fd_t fd, const char *secKey, void *ssl, const char *extensions, size_t extensionsLength) {
         upgrade(fd, secKey, ssl, extensions, extensionsLength);
@@ -196,6 +197,11 @@ void Server::onDisconnection(std::function<void (WebSocket, int, char *, size_t)
 void Server::onMessage(std::function<void (WebSocket, char *, size_t, OpCode)> messageCallback)
 {
     this->messageCallback = messageCallback;
+}
+
+void Server::onPing(std::function<void (WebSocket, char *, size_t)> pingCallback)
+{
+    this->pingCallback = pingCallback;
 }
 
 void Server::onPong(std::function<void (WebSocket, char *, size_t)> pongCallback)

--- a/src/Server.h
+++ b/src/Server.h
@@ -56,6 +56,7 @@ private:
     std::function<void(WebSocket)> connectionCallback;
     std::function<void(WebSocket, int code, char *message, size_t length)> disconnectionCallback;
     std::function<void(WebSocket, char *, size_t, OpCode)> messageCallback;
+    std::function<void(WebSocket, char *, size_t)> pingCallback;
     std::function<void(WebSocket, char *, size_t)> pongCallback;
 public:
     Server(int port = 0, bool master = true, int options = 0, int maxPayload = 1048576);
@@ -66,6 +67,7 @@ public:
     void onConnection(std::function<void(WebSocket)> connectionCallback);
     void onDisconnection(std::function<void(WebSocket, int code, char *message, size_t length)> disconnectionCallback);
     void onMessage(std::function<void(WebSocket, char *, size_t, OpCode)> messageCallback);
+    void onPing(std::function<void(WebSocket, char *, size_t)> pingCallback);
     void onPong(std::function<void(WebSocket, char *, size_t)> pongCallback);
     void close(bool force = false);
     void upgrade(uv_os_fd_t fd, const char *secKey, void *ssl = nullptr, const char *extensions = nullptr, size_t extensionsLength = 0);

--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -176,6 +176,7 @@ void WebSocket::handleFragment(const char *fragment, size_t length, OpCode opCod
             } else {
                 if (opCode == PING) {
                     send((char *) socketData->controlBuffer.c_str(), socketData->controlBuffer.length(), OpCode::PONG);
+                    socketData->server->pingCallback(p, (char *) socketData->controlBuffer.c_str(), socketData->controlBuffer.length());
                 } else if (opCode == PONG) {
                     socketData->server->pongCallback(p, (char *) socketData->controlBuffer.c_str(), socketData->controlBuffer.length());
                 }


### PR DESCRIPTION
In our case (and I'm sure a lot of other cases as well) it would be more logical to have clients ping the server and handle those accordingly. To support this, I added an onPing event listener. When a `ping` is received, a `pong` is still sent back, but a callback is also triggered.