### PR TITLE
Add CMake dependency lookup, force use C++11 standard.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,27 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_STANDARD 11)
 project (µWebSockets)
 
-add_subdirectory(examples)
+find_package(OpenSSL REQUIRED)
+find_package(ZLIB REQUIRED)
+
+find_path(LIBUV_INCLUDE_DIR uv.h)
+find_library(LIBUV_LIBRARY NAMES uv uv1)
 
 add_library(uWS SHARED src/Extensions.cpp src/HTTPSocket.cpp src/Network.cpp src/Server.cpp src/UTF8.cpp src/WebSocket.cpp)
 target_include_directories(uWS PUBLIC src)
-target_compile_features(uWS PRIVATE cxx_nullptr)
-target_link_libraries (uWS LINK_PUBLIC uv)
-target_link_libraries (uWS LINK_PUBLIC ssl)
-target_link_libraries (uWS LINK_PUBLIC crypto)
-target_link_libraries (uWS LINK_PUBLIC z)
+
+target_include_directories(uWS PUBLIC ${LIBUV_INCLUDE_DIR})
+target_include_directories(uWS PUBLIC ${LIBUV_INCLUDE_DIR})
+target_include_directories(uWS PUBLIC ${ZLIB_INCLUDE_DIRS})
+target_link_libraries (uWS LINK_PUBLIC ${LIBUV_LIBRARY})
+target_link_libraries (uWS LINK_PUBLIC ${OPENSSL_SSL_LIBRARY})
+target_link_libraries (uWS LINK_PUBLIC ${OPENSSL_CRYPTO_LIBRARY})
+target_link_libraries (uWS LINK_PUBLIC ${ZLIB_LIBRARY})
 
 if (UNIX)
 target_link_libraries (uWS LINK_PUBLIC pthread)
 endif (UNIX)
+
+add_subdirectory(examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,7 @@
 add_executable(echo echo.cpp)
 target_include_directories(echo PUBLIC ../src)
-target_compile_features(echo PRIVATE cxx_nullptr)
 target_link_libraries (echo LINK_PUBLIC uWS)
 
 add_executable(multithreaded_echo multithreaded_echo.cpp)
 target_include_directories(multithreaded_echo PUBLIC ../src)
-target_compile_features(multithreaded_echo PRIVATE cxx_nullptr)
 target_link_libraries (multithreaded_echo LINK_PUBLIC uWS)


### PR DESCRIPTION
find_package is used to look for openssl and zlib.
find_path/find_library are used to look for libuv, as CMake do not have built-in support for libuv lookup.

This change make cmake finding all decencies automatically and report any missing library at configure time instead of compiling or linking time.

CMAKE_CXX_STANDARD is also set to force use C++11. target_compile_features with cxx_nullptr statements are removed.