### PR TITLE
Set SO_REUSEADDR before bind.

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -151,7 +151,10 @@ Server::Server(int port, bool master, int options, int maxPayload, SSLContext ss
         listenPoll = new uv_poll_t;
         listenPoll->data = this;
 
-        if (bind(listenFd, (sockaddr *) &listenAddr, sizeof(sockaddr_in)) | listen(listenFd, 10)) {
+        int on = 1;
+        setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+
+        if (bind(listenFd, (sockaddr *) &listenAddr, sizeof(sockaddr_in)) || listen(listenFd, 10)) {
             throw ERR_LISTEN;
         }
 


### PR DESCRIPTION
This pull request sets SO_REUSEADDR on the listening socket. 

Reason:

When killing servers with connections still connected, active sockets will enter TIME_WAIT state. If you try to start the server again, `ERR_LISTEN` will be thrown. This forbids us to restart server with live traffic.