### PR TITLE
Fix typo in node.js client verification

### DIFF
--- a/nodejs/dist/uws.js
+++ b/nodejs/dist/uws.js
@@ -345,7 +345,7 @@ class Server extends EventEmitter {
                                 });
                             } else {
                                 // todo: send code & message
-                                if (this.__lastUpgradeListener) {
+                                if (this._lastUpgradeListener) {
                                     socket.end();
                                 }
                             }


### PR DESCRIPTION
Our clients weren't trying to reconnect when the verification failed, this seems to be the reason why...