### PR TITLE
add dependency declaration to meson.build

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,7 +1,7 @@
 echoexe = executable('echo', 'echo.cpp',
         include_directories : inc,
-        link_with : uWSlib)
+        link_with : uWS_lib)
 
 multiechoexe = executable('multithreaded_echo', 'multithreaded_echo.cpp',
 		include_directories : inc,
-		link_with : uWSlib, dependencies: [thread_dep])
+		link_with : uWS_lib, dependencies: [thread_dep])

--- a/meson.build
+++ b/meson.build
@@ -9,3 +9,5 @@ uv_dep = dependency('libuv', version : '>=1.0')
 
 subdir('src')
 subdir('examples')
+
+uWS_dep = declare_dependency(include_directories:inc, link_with: uWS_lib)

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,5 +17,5 @@ inst_headers = [
 
 install_headers(inst_headers, subdir: 'uWS')
 
-uWSlib = library('uWS', prog_sources, include_directories: inc,
+uWS_lib = library('uWS', prog_sources, include_directories: inc,
 		dependencies : [zlib_dep, ssl_dep, uv_dep, thread_dep])


### PR DESCRIPTION
This commit simplifies importing uWS to other meson projects.
Now only a single line will handle imports(both system, fallback to git repo) -
```uWS_dep = dependency('uWS', fallback : ['uWS', 'uWS_dep'])```