### PR TITLE
Pass the Sec-Websocket-Protocol header through from Node

### DIFF
--- a/nodejs/addon.h
+++ b/nodejs/addon.h
@@ -205,10 +205,11 @@ void upgrade(const FunctionCallbackInfo<Value> &args) {
     Ticket *ticket = (Ticket *) args[1].As<External>()->Value();
     NativeString secKey(args[2]);
     NativeString extensions(args[3]);
+    NativeString subprotocol(args[4]);
 
     // todo: move this check into core!
     if (ticket->fd != INVALID_SOCKET) {
-        hub.upgrade(ticket->fd, secKey.getData(), ticket->ssl, extensions.getData(), extensions.getLength(), serverGroup);
+        hub.upgrade(ticket->fd, secKey.getData(), ticket->ssl, extensions.getData(), extensions.getLength(), subprotocol.getData(), subprotocol.getLength(), serverGroup);
     } else {
         if (ticket->ssl) {
             SSL_free(ticket->ssl);

--- a/nodejs/dist/uws.js
+++ b/nodejs/dist/uws.js
@@ -438,7 +438,7 @@ class Server extends EventEmitter {
                 if (this.serverGroup) {
                     _upgradeReq = request;
                     this._upgradeCallback = callback ? callback : noop;
-                    native.upgrade(this.serverGroup, ticket, secKey, request.headers['sec-websocket-extensions']);
+                    native.upgrade(this.serverGroup, ticket, secKey, request.headers['sec-websocket-extensions'], request.headers['sec-websocket-protocol']);
                 }
             });
         }

--- a/src/Hub.cpp
+++ b/src/Hub.cpp
@@ -125,7 +125,7 @@ void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh)
     }
 }
 
-bool Hub::upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *extensions, size_t extensionsLength, Group<SERVER> *serverGroup) {
+bool Hub::upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *extensions, size_t extensionsLength, const char *subprotocol, size_t subprotocolLength, Group<SERVER> *serverGroup) {
     if (!serverGroup) {
         serverGroup = &getDefaultGroup<SERVER>();
     }
@@ -148,7 +148,7 @@ bool Hub::upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *ext
         }
     }
 
-    if (HTTPSocket<SERVER>(s).upgrade(secKey, extensionsResponse.data(), extensionsResponse.length())) {
+    if (HTTPSocket<SERVER>(s).upgrade(secKey, extensionsResponse.data(), extensionsResponse.length(), subprotocol, subprotocolLength)) {
         s.enterState<WebSocket<SERVER>>(new WebSocket<SERVER>::Data(perMessageDeflate, s.getSocketData()));
         serverGroup->addWebSocket(s);
         serverGroup->connectionHandler(WebSocket<SERVER>(s), {nullptr, nullptr, 0, 0});

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -40,7 +40,7 @@ struct WIN32_EXPORT Hub : private uS::Node, public Group<SERVER>, public Group<C
 
     bool listen(int port, uS::TLS::Context sslContext = nullptr, int options = 0, Group<SERVER> *eh = nullptr);
     void connect(std::string uri, void *user, int timeoutMs = 5000, Group<CLIENT> *eh = nullptr);
-    bool upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *extensions, size_t extensionsLength, Group<SERVER> *serverGroup = nullptr);
+    bool upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *extensions, size_t extensionsLength, const char *subprotocol, size_t subprotocolLength, Group<SERVER> *serverGroup = nullptr);
 
     Hub(int extensionOptions = 0, bool useDefaultLoop = false) : uS::Node(LARGE_BUFFER_SIZE, WebSocketProtocol<SERVER>::CONSUME_PRE_PADDING, WebSocketProtocol<SERVER>::CONSUME_POST_PADDING, useDefaultLoop),
                                              Group<SERVER>(extensionOptions, this, nodeData), Group<CLIENT>(0, this, nodeData) {


### PR DESCRIPTION
This PR allows the `Sec-Websocket-Protocol` header to be passed from Node to C++ so that the header can be echoed back in the response. This prevents the following error: `Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' header but no response was received`, similar to https://github.com/uWebSockets/uWebSockets/issues/263

Please let me know if there's anything you'd like done differently, as I am very new to this repo. Thanks!