### PR TITLE
add support for libuv >= 2.0.0

### DIFF
--- a/src/Hub.h
+++ b/src/Hub.h
@@ -7,7 +7,7 @@
 #include <zlib.h>
 #include <mutex>
 
-static_assert (UV_VERSION_MINOR >= 3, "µWebSockets requires libuv >=1.3.0");
+static_assert (UV_VERSION_MAJOR >= 2 || (UV_VERSION_MAJOR >= 1 && UV_VERSION_MINOR >= 3), "µWebSockets requires libuv >=1.3.0");
 
 namespace uWS {
 


### PR DESCRIPTION
libuv [master branch is 2.0.0](https://github.com/libuv/libuv/blob/master/include/uv-version.h). Closes #329 