### PR TITLE
allow access to httpheaders on connection handler

### DIFF
--- a/src/Group.h
+++ b/src/Group.h
@@ -15,10 +15,10 @@ struct Hub;
 struct UpgradeInfo {
     char *path, *subprotocol;
     size_t pathLength, subprotocolLength;
-    uWS::HTTPParser httpParser;
+    HTTPParser httpParser;
 
     std::map<std::string, std::string> getRequestHeaders() {
-        char* curCursor = httpParser.cursor;
+        char *curCursor = httpParser.cursor;
         httpParser.cursor = httpParser.headerBegin;
         std::map<std::string, std::string> headers;
 

--- a/src/Group.h
+++ b/src/Group.h
@@ -14,32 +14,32 @@ struct Hub;
 
 struct UpgradeInfo {
     char *path, *subprotocol;
-	size_t pathLength, subprotocolLength;
-	uWS::HTTPParser httpParser;
+    size_t pathLength, subprotocolLength;
+    uWS::HTTPParser httpParser;
 
-	std::map<std::string, std::string> getRequestHeaders() {
-		char* curCursor = httpParser.cursor;
-		httpParser.cursor = httpParser.headerBegin;
-		std::map<std::string, std::string> headers;
+    std::map<std::string, std::string> getRequestHeaders() {
+        char* curCursor = httpParser.cursor;
+        httpParser.cursor = httpParser.headerBegin;
+        std::map<std::string, std::string> headers;
 
-		for (httpParser++; httpParser.key.second; httpParser++) {
-			std::string key;
-			key.resize(httpParser.key.second);
+        for (httpParser++; httpParser.key.second; httpParser++) {
+            std::string key;
+            key.resize(httpParser.key.second);
 
-			size_t i = 0;
-			for (; i < httpParser.key.second; i++) {
-				key[i] = tolower(httpParser.key.first[i]);
-			}
-			key[i] = 0;
+            size_t i = 0;
+            for (; i < httpParser.key.second; i++) {
+                key[i] = tolower(httpParser.key.first[i]);
+            }
+            key[i] = 0;
 
-			headers[key] = std::string(httpParser.value.first, httpParser.value.second);
-		}
+            headers[key] = std::string(httpParser.value.first, httpParser.value.second);
+        }
 
-		// restore cursor back to its original position
-		httpParser.cursor = curCursor;
+        // restore cursor back to its original position
+        httpParser.cursor = curCursor;
 
-		return headers;
-	}
+        return headers;
+    }
 };
 
 template <bool isServer>

--- a/src/Group.h
+++ b/src/Group.h
@@ -26,11 +26,11 @@ struct UpgradeInfo {
             std::string key;
             key.resize(httpParser.key.second);
 
+            // lowercase the header key
             size_t i = 0;
             for (; i < httpParser.key.second; i++) {
                 key[i] = tolower(httpParser.key.first[i]);
             }
-            key[i] = 0;
 
             headers[key] = std::string(httpParser.value.first, httpParser.value.second);
         }

--- a/src/Group.h
+++ b/src/Group.h
@@ -23,12 +23,9 @@ struct UpgradeInfo {
         std::map<std::string, std::string> headers;
 
         for (httpParser++; httpParser.key.second; httpParser++) {
-            std::string key;
-            key.resize(httpParser.key.second);
-
-            for (size_t i = 0; i < httpParser.key.second; i++) {
-                key[i] = tolower(httpParser.key.first[i]);
-            }
+            // key lower cased
+            std::string key(httpParser.key.first, httpParser.key.second);
+            std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 
             headers[key] = std::string(httpParser.value.first, httpParser.value.second);
         }

--- a/src/Group.h
+++ b/src/Group.h
@@ -26,8 +26,7 @@ struct UpgradeInfo {
             std::string key;
             key.resize(httpParser.key.second);
 
-            size_t i = 0;
-            for (; i < httpParser.key.second; i++) {
+            for (size_t i = 0; i < httpParser.key.second; i++) {
                 key[i] = tolower(httpParser.key.first[i]);
             }
 

--- a/src/Group.h
+++ b/src/Group.h
@@ -3,8 +3,10 @@
 
 #include "WebSocket.h"
 #include "Extensions.h"
+#include "HTTPSocket.h"
 #include <functional>
 #include <stack>
+#include <map>
 
 namespace uWS {
 
@@ -12,7 +14,32 @@ struct Hub;
 
 struct UpgradeInfo {
     char *path, *subprotocol;
-    size_t pathLength, subprotocolLength;
+	size_t pathLength, subprotocolLength;
+	uWS::HTTPParser httpParser;
+
+	std::map<std::string, std::string> getRequestHeaders() {
+		char* curCursor = httpParser.cursor;
+		httpParser.cursor = httpParser.headerBegin;
+		std::map<std::string, std::string> headers;
+
+		for (httpParser++; httpParser.key.second; httpParser++) {
+			std::string key;
+			key.resize(httpParser.key.second);
+
+			size_t i = 0;
+			for (; i < httpParser.key.second; i++) {
+				key[i] = tolower(httpParser.key.first[i]);
+			}
+			key[i] = 0;
+
+			headers[key] = std::string(httpParser.value.first, httpParser.value.second);
+		}
+
+		// restore cursor back to its original position
+		httpParser.cursor = curCursor;
+
+		return headers;
+	}
 };
 
 template <bool isServer>

--- a/src/Group.h
+++ b/src/Group.h
@@ -26,7 +26,6 @@ struct UpgradeInfo {
             std::string key;
             key.resize(httpParser.key.second);
 
-            // lowercase the header key
             size_t i = 0;
             for (; i < httpParser.key.second; i++) {
                 key[i] = tolower(httpParser.key.first[i]);

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -81,7 +81,7 @@ void HTTPSocket<isServer>::onData(uS::Socket s, char *data, int length) {
                     //s.cork(true);
                     ((Group<SERVER> *) s.getSocketData()->nodeData)->connectionHandler(WebSocket<SERVER>(s), {path.first, subprotocol.first,
                                                                                                               path.second, subprotocol.second,
-																											  HTTPParser((char *)httpData->httpBuffer.data())});
+                                                                                                              HTTPParser((char *)httpData->httpBuffer.data())});
                     //s.cork(false);
                     delete httpData;
                 }

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -81,7 +81,7 @@ void HTTPSocket<isServer>::onData(uS::Socket s, char *data, int length) {
                     //s.cork(true);
                     ((Group<SERVER> *) s.getSocketData()->nodeData)->connectionHandler(WebSocket<SERVER>(s), {path.first, subprotocol.first,
                                                                                                               path.second, subprotocol.second,
-                                                                                                              HTTPParser((char *)httpData->httpBuffer.data())});
+                                                                                                              HTTPParser((char *) httpData->httpBuffer.data())});
                     //s.cork(false);
                     delete httpData;
                 }

--- a/src/HTTPSocket.h
+++ b/src/HTTPSocket.h
@@ -35,39 +35,39 @@ private:
 };
 
 struct HTTPParser {
-	char* headerBegin;
-	char* cursor;
-	std::pair<char *, size_t> key, value;
-	HTTPParser(char *cursor) : cursor(cursor), headerBegin(cursor) {
-		size_t length;
-		for (; isspace(*cursor); cursor++);
-		for (length = 0; !isspace(cursor[length]) && cursor[length] != '\r'; length++);
-		key = { cursor, length };
-		cursor += length + 1;
-		for (length = 0; !isspace(cursor[length]) && cursor[length] != '\r'; length++);
-		value = { cursor, length };
-	}
-	HTTPParser &operator++(int) {
-		size_t length = 0;
-		for (; !(cursor[0] == '\r' && cursor[1] == '\n'); cursor++);
-		cursor += 2;
-		if (cursor[0] == '\r' && cursor[1] == '\n') {
-			key = value = { 0, 0 };
-		} else {
-			for (; cursor[length] != ':' && cursor[length] != '\r'; length++);
-			key = { cursor, length };
-			if (cursor[length] != '\r') {
-				cursor += length;
-				length = 0;
-				while (isspace(*(++cursor)));
-				for (; cursor[length] != '\r'; length++);
-				value = { cursor, length };
-			} else {
-				value = { 0, 0 };
-			}
-		}
-		return *this;
-	}
+    char* headerBegin;
+    char* cursor;
+    std::pair<char *, size_t> key, value;
+    HTTPParser(char *cursor) : cursor(cursor), headerBegin(cursor) {
+        size_t length;
+        for (; isspace(*cursor); cursor++);
+        for (length = 0; !isspace(cursor[length]) && cursor[length] != '\r'; length++);
+        key = { cursor, length };
+        cursor += length + 1;
+        for (length = 0; !isspace(cursor[length]) && cursor[length] != '\r'; length++);
+        value = { cursor, length };
+    }
+    HTTPParser &operator++(int) {
+        size_t length = 0;
+        for (; !(cursor[0] == '\r' && cursor[1] == '\n'); cursor++);
+        cursor += 2;
+        if (cursor[0] == '\r' && cursor[1] == '\n') {
+            key = value = { 0, 0 };
+        } else {
+            for (; cursor[length] != ':' && cursor[length] != '\r'; length++);
+            key = { cursor, length };
+            if (cursor[length] != '\r') {
+                cursor += length;
+                length = 0;
+                while (isspace(*(++cursor)));
+                for (; cursor[length] != '\r'; length++);
+                value = { cursor, length };
+            } else {
+                value = { 0, 0 };
+            }
+        }
+        return *this;
+    }
 };
 
 }

--- a/src/HTTPSocket.h
+++ b/src/HTTPSocket.h
@@ -35,8 +35,8 @@ private:
 };
 
 struct HTTPParser {
-    char* headerBegin;
-    char* cursor;
+    char *headerBegin;
+    char *cursor;
     std::pair<char *, size_t> key, value;
     HTTPParser(char *cursor) : cursor(cursor), headerBegin(cursor) {
         size_t length;

--- a/src/Hub.cpp
+++ b/src/Hub.cpp
@@ -151,7 +151,7 @@ bool Hub::upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *ext
     if (HTTPSocket<SERVER>(s).upgrade(secKey, extensionsResponse.data(), extensionsResponse.length(), subprotocol, subprotocolLength)) {
         s.enterState<WebSocket<SERVER>>(new WebSocket<SERVER>::Data(perMessageDeflate, s.getSocketData()));
         serverGroup->addWebSocket(s);
-        serverGroup->connectionHandler(WebSocket<SERVER>(s), {nullptr, nullptr, 0, 0});
+        serverGroup->connectionHandler(WebSocket<SERVER>(s), {nullptr, nullptr, 0, 0, HTTPParser(nullptr)});
         delete temporaryHttpData;
         return true;
     }


### PR DESCRIPTION
This exposes the HTTPParser to onConnection's upgradeinfo. I have also implemented a simpler way to parse the headers, through `uWS::UpgradeInfo::getRequestHeaders()`, which returns a `std::map<std::string, std::string>`. There's a small overhead of copying/allocating the strings and the map, but people can still use the HTTPParser if zero-copy parsing is required.

**Example:**
```cpp
int main()
{
    uWS::Hub h;

    h.onConnection([](uWS::WebSocket<uWS::SERVER> ws, uWS::UpgradeInfo ui) {
        // headers
        const std::map<std::string, std::string>& headers = ui.getRequestHeaders();
        for (auto i = headers.begin(); i != headers.end(); i++) {
            // i->first: header key; i->second: header value
            std::cout << i->first << ": " << i->second << std::endl;
        }
    });

    h.onMessage([](uWS::WebSocket<uWS::SERVER> ws, char *message, size_t length, uWS::OpCode opCode) {
        ws.send(message, length, opCode);
    });

    h.listen(3000);
    h.run();
}
```