### PR TITLE
Fix for node-gyp rebuild on Windows (cmd/powershell)

### DIFF
--- a/nodejs/dist/binding.gyp
+++ b/nodejs/dist/binding.gyp
@@ -45,17 +45,35 @@
       'target_name': 'action_after_build',
       'type': 'none',
       'dependencies': [ 'uws' ],
-      'actions': [
-        {
-          'action_name': 'move_lib',
-          'inputs': [
-            '<@(PRODUCT_DIR)/uws.node'
-          ],
-          'outputs': [
-            'uws'
-          ],
-          'action': ['cp', '<@(PRODUCT_DIR)/uws.node', 'uws_<!@(node -p process.platform)_<!@(node -p process.versions.modules).node']
-        }
+      'conditions': [
+        ['OS!="win"', {
+            'actions': [
+              {
+                'action_name': 'move_lib',
+                'inputs': [
+                  '<@(PRODUCT_DIR)/uws.node'
+                ],
+                'outputs': [
+                  'uws'
+                ],
+                'action': ['cp', '<@(PRODUCT_DIR)/uws.node', 'uws_<!@(node -p process.platform)_<!@(node -p process.versions.modules).node']
+              }
+            ]}
+        ],
+        ['OS=="win"', {
+            'actions': [
+              {
+                'action_name': 'move_lib',
+                'inputs': [
+                  '<@(PRODUCT_DIR)/uws.node'
+                ],
+                'outputs': [
+                  'uws'
+                ],
+                'action': ['copy', '<@(PRODUCT_DIR)/uws.node', 'uws_<!@(node -p process.platform)_<!@(node -p process.versions.modules).node']
+              }
+            ]}
+        ]
       ]
     }
   ]


### PR DESCRIPTION
As described in #349.

Apologies if it's not the right way to do it, initially I tried to use `copies` but that didn't seem to have the option to change a name.