### PR TITLE
Fix CMakeLists.txt to specify C++ 11 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
 set(CMAKE_BUILD_TYPE Release)
-set(CMAKE_CXX_STANDARD 11)
-if(CMAKE_VERSION VERSION_LESS "3.1")
-    # CMake 3.0 does not implement "CMAKE_CXX_STANDARD":
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        set(CMAKE_CXX_FLAGS "--std=gnu++11 ${CMAKE_CXX_FLAGS}")
-    endif()
-endif()
 project (µWebSockets)
 
 option(BUILD_SHARED_LIBS "Build shared libraries." ON)
@@ -22,6 +15,14 @@ if(NOT LIBUV_LIBRARY)
 endif()
 
 add_library(uWS src/Extensions.cpp src/Group.cpp src/WebSocketImpl.cpp src/Networking.cpp src/Hub.cpp src/Node.cpp src/WebSocket.cpp src/HTTPSocket.cpp src/Socket.cpp)
+if(CMAKE_VERSION VERSION_LESS "3.1")
+    # CMake 3.0 does not implement "CMAKE_CXX_STANDARD":
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        set(CMAKE_CXX_FLAGS "--std=gnu++11 ${CMAKE_CXX_FLAGS}")
+    endif()
+else()
+    set_property(TARGET uWS PROPERTY CMAKE_CXX_STANDARD 11)
+endif()
 target_include_directories(uWS PUBLIC src)
 
 target_include_directories(uWS PUBLIC ${LIBUV_INCLUDE_DIR})


### PR DESCRIPTION
Use `set_property` instead of `set` for `CMAKE_CXX_STANDARD` or
`CXX_STANDARD`. Only tested with GNU compilers.

The compiler check can probably be omitted if the flag was changed to `--std=c++11`.