### PR TITLE
Fixed CMakeLists.txt C++ 11 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_CXX_STANDARD 11)
 project (µWebSockets)
 
 option(BUILD_SHARED_LIBS "Build shared libraries." ON)
@@ -20,8 +21,6 @@ if(CMAKE_VERSION VERSION_LESS "3.1")
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         set(CMAKE_CXX_FLAGS "--std=gnu++11 ${CMAKE_CXX_FLAGS}")
     endif()
-else()
-    set_property(TARGET uWS PROPERTY CMAKE_CXX_STANDARD 11)
 endif()
 target_include_directories(uWS PUBLIC src)
 


### PR DESCRIPTION
CMAKE_CXX_STANDARD is a variable instead of a property. From testing,
it has to be defined before add_library. On the other hand,
CMAKE_CXX_FLAGS has to be set after add_library.

Turns out the previous fix made CMake work for people using versions <3.1 and not the rest, when the reverse was true before.