### PR TITLE
Added static library build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,12 @@ default:
 	make `(uname -s)`
 Linux:
 	g++ $(CPP_SHARED) -s -o libuWS.so
+	g++ $(CPP_SHARED) -s -c
+	ar rvs libuWS.a *.o
 Darwin:
 	g++ $(CPP_SHARED) $(CPP_OSX) -o libuWS.so
+	g++ $(CPP_SHARED) $(CPP_OSX) -s -c
+	ar rvs libuWS.a *.o
 .PHONY: install
 install:
 	if [ -d "/usr/lib64" ]; then cp libuWS.so /usr/lib64/; else cp libuWS.so /usr/lib/; fi
@@ -15,3 +19,4 @@ install:
 .PHONY: clean
 clean:
 	rm libuWS.so
+	rm *.o


### PR DESCRIPTION
By default the Makefile now builds a static library target in the main directory. The .o files have been added to the clean target.
Related to issue #404