### PR TITLE
Teach client connection about "Sec-WebSocket-Protocol" header.

### DIFF
--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -247,7 +247,7 @@ bool HttpSocket<isServer>::upgrade(const char *secKey, const char *extensions, s
         }
     } else {
         std::string optionalSubprotocol;
-        if(!getData()->subprotocol.empty()) {
+        if (!getData()->subprotocol.empty()) {
             optionalSubprotocol = "Sec-WebSocket-Protocol: " + getData()->subprotocol + "\r\n";
         }
         std::string upgradeHeaderBuffer = std::string("GET /") + getData()->path + " HTTP/1.1\r\n"

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -246,11 +246,16 @@ bool HttpSocket<isServer>::upgrade(const char *secKey, const char *extensions, s
             return false;
         }
     } else {
+        std::string optionalSubprotocol;
+        if(!getData()->subprotocol.empty()) {
+            optionalSubprotocol = "Sec-WebSocket-Protocol: " + getData()->subprotocol + "\r\n";
+        }
         std::string upgradeHeaderBuffer = std::string("GET /") + getData()->path + " HTTP/1.1\r\n"
                                                                                    "Upgrade: websocket\r\n"
                                                                                    "Connection: Upgrade\r\n"
                                                                                    "Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==\r\n"
                                                                                    "Host: " + getData()->host + "\r\n"
+                                                                                   + optionalSubprotocol +
                                                                                    "Sec-WebSocket-Version: 13\r\n\r\n";
 
         uS::SocketData::Queue::Message *messagePtr = allocMessage(upgradeHeaderBuffer.length(), upgradeHeaderBuffer.data());

--- a/src/HTTPSocket.h
+++ b/src/HTTPSocket.h
@@ -116,6 +116,7 @@ struct WIN32_EXPORT HttpSocket : private uS::Socket {
         // todo: limit these to only client, but who cares for now?
         std::string path;
         std::string host;
+        std::string subprotocol;
         void *httpUser;
 
         // used to close sockets not sending requests in time

--- a/src/Hub.cpp
+++ b/src/Hub.cpp
@@ -75,7 +75,7 @@ bool Hub::listen(int port, uS::TLS::Context sslContext, int options, Group<SERVE
     return true;
 }
 
-void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh, std::string subprotocol ) {
+void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh, std::string subprotocol) {
     if (!eh) {
         eh = (Group<CLIENT> *) this;
     }

--- a/src/Hub.cpp
+++ b/src/Hub.cpp
@@ -75,7 +75,7 @@ bool Hub::listen(int port, uS::TLS::Context sslContext, int options, Group<SERVE
     return true;
 }
 
-void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh) {
+void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh, std::string subprotocol ) {
     if (!eh) {
         eh = (Group<CLIENT> *) this;
     }
@@ -117,6 +117,7 @@ void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh)
         httpSocketData->host = hostname;
         httpSocketData->path = path;
         httpSocketData->httpUser = user;
+        httpSocketData->subprotocol = subprotocol;
 
         uS::Socket s = uS::Node::connect<onClientConnection>(hostname.c_str(), port, secure, httpSocketData);
         if (s) {

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -39,7 +39,7 @@ struct WIN32_EXPORT Hub : private uS::Node, public Group<SERVER>, public Group<C
     static void onClientConnection(uS::Socket s, bool error);
 
     bool listen(int port, uS::TLS::Context sslContext = nullptr, int options = 0, Group<SERVER> *eh = nullptr);
-    void connect(std::string uri, void *user, int timeoutMs = 5000, Group<CLIENT> *eh = nullptr);
+    void connect(std::string uri, void *user, int timeoutMs = 5000, Group<CLIENT> *eh = nullptr, std::string subprotocol = "");
     bool upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *extensions, size_t extensionsLength, const char *subprotocol, size_t subprotocolLength, Group<SERVER> *serverGroup = nullptr);
 
     Hub(int extensionOptions = 0, bool useDefaultLoop = false) : uS::Node(LARGE_BUFFER_SIZE, WebSocketProtocol<SERVER>::CONSUME_PRE_PADDING, WebSocketProtocol<SERVER>::CONSUME_POST_PADDING, useDefaultLoop),


### PR DESCRIPTION
To simplify testing of ui.subprotocol, using just the uWebSockets library, teach the `uWS::WebSocket<uWS::CLIENT>` how to set an optional Sec-WebSocket-Protocol header.

To attempt to minimise API change this is done by adding an extra optional parameter to the end of the Hub::connect() function.