### PR TITLE
nodejs: don't attempt to upgrade closed sockets

### DIFF
--- a/nodejs/dist/uws.js
+++ b/nodejs/dist/uws.js
@@ -102,7 +102,7 @@ class WebSocket {
         } else {
             this.internalOnOpen = noop;
         }
-    }   
+    }
 
     set onclose(f) {
         if (f) {
@@ -463,7 +463,7 @@ class Server extends EventEmitter {
             const secKey = request.headers['sec-websocket-key'];
             const socketHandle = socket.ssl ? socket._parent._handle : socket._handle;
             const sslState = socket.ssl ? socket.ssl._external : null;
-            if (secKey && secKey.length == 24) {
+            if (socketHandle && secKey && secKey.length == 24) {
                 socket.setNoDelay(this._noDelay);
                 const ticket = native.transfer(socketHandle.fd === -1 ? socketHandle : socketHandle.fd, sslState);
                 socket.on('close', (error) => {


### PR DESCRIPTION
ported from: https://github.com/primus/primus/pull/531
fixes: https://github.com/uWebSockets/uWebSockets/issues/326

Not sure if the checks for `.writeable` and `.readable` like it was done for primus are necessary, so I went with a boolean check on the handle.

Can't run autobahn right now because of https://github.com/uWebSockets/uWebSockets/issues/430.