### PR TITLE
Expose uv_run_mode

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -53,10 +53,10 @@ Node::Node(int recvLength, int prePadding, int postPadding, bool useDefaultLoop)
     SSL_CTX_set_options(nodeData->clientContext, SSL_OP_NO_SSLv3);
 }
 
-void Node::run(uv_run_mode mode) {
+int Node::run(uv_run_mode mode) {
     nodeData->tid = pthread_self();
 
-    uv_run(loop, mode);
+    return uv_run(loop, mode);
 }
 
 Node::~Node() {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -53,10 +53,10 @@ Node::Node(int recvLength, int prePadding, int postPadding, bool useDefaultLoop)
     SSL_CTX_set_options(nodeData->clientContext, SSL_OP_NO_SSLv3);
 }
 
-void Node::run() {
+void Node::run(uv_run_mode mode) {
     nodeData->tid = pthread_self();
 
-    uv_run(loop, UV_RUN_DEFAULT);
+    uv_run(loop, mode);
 }
 
 Node::~Node() {

--- a/src/Node.h
+++ b/src/Node.h
@@ -21,7 +21,7 @@ protected:
 public:
     Node(int recvLength = 1024, int prePadding = 0, int postPadding = 0, bool useDefaultLoop = false);
     ~Node();
-    void run();
+    void run(uv_run_mode mode = UV_RUN_DEFAULT);
 
     uv_loop_t *getLoop() {
         return loop;

--- a/src/Node.h
+++ b/src/Node.h
@@ -21,7 +21,7 @@ protected:
 public:
     Node(int recvLength = 1024, int prePadding = 0, int postPadding = 0, bool useDefaultLoop = false);
     ~Node();
-    void run(uv_run_mode mode = UV_RUN_DEFAULT);
+    int run(uv_run_mode mode = UV_RUN_DEFAULT);
 
     uv_loop_t *getLoop() {
         return loop;


### PR DESCRIPTION
In some cases, running uws should not block the calling thread. For example, if you have another I/O process running like rdkafka and need to call both uws' run and rdkafka's run function in your own loop.

This PR simply exposes the underlying uv's option to set the mode to do just that, without breaking backwards compatibility.