### PR TITLE
Allow listening on specific addresses

### DIFF
--- a/src/Hub.cpp
+++ b/src/Hub.cpp
@@ -63,16 +63,20 @@ void Hub::onClientConnection(uS::Socket s, bool error) {
     }
 }
 
-bool Hub::listen(int port, uS::TLS::Context sslContext, int options, Group<SERVER> *eh) {
+bool Hub::listen(const char *host, int port, uS::TLS::Context sslContext, int options, Group<SERVER> *eh) {
     if (!eh) {
         eh = (Group<SERVER> *) this;
     }
 
-    if (uS::Node::listen<onServerAccept>(port, sslContext, options, (uS::NodeData *) eh, nullptr)) {
+    if (uS::Node::listen<onServerAccept>(host, port, sslContext, options, (uS::NodeData *) eh, nullptr)) {
         eh->errorHandler(port);
         return false;
     }
     return true;
+}
+
+bool Hub::listen(int port, uS::TLS::Context sslContext, int options, Group<SERVER> *eh) {
+    return listen(nullptr, port, sslContext, options, eh);
 }
 
 void Hub::connect(std::string uri, void *user, int timeoutMs, Group<CLIENT> *eh, std::string subprotocol) {

--- a/src/Hub.h
+++ b/src/Hub.h
@@ -39,6 +39,7 @@ struct WIN32_EXPORT Hub : private uS::Node, public Group<SERVER>, public Group<C
     static void onClientConnection(uS::Socket s, bool error);
 
     bool listen(int port, uS::TLS::Context sslContext = nullptr, int options = 0, Group<SERVER> *eh = nullptr);
+    bool listen(const char *host, int port, uS::TLS::Context sslContext = nullptr, int options = 0, Group<SERVER> *eh = nullptr);
     void connect(std::string uri, void *user, int timeoutMs = 5000, Group<CLIENT> *eh = nullptr, std::string subprotocol = "");
     void upgrade(uv_os_sock_t fd, const char *secKey, SSL *ssl, const char *extensions, size_t extensionsLength, const char *subprotocol, size_t subprotocolLength, Group<SERVER> *serverGroup = nullptr);
 

--- a/src/Node.h
+++ b/src/Node.h
@@ -158,7 +158,7 @@ public:
 
     // todo: hostname, backlog
     template <void A(Socket s)>
-    bool listen(int port, uS::TLS::Context sslContext, int options, uS::NodeData *nodeData, void *user) {
+    bool listen(const char *host, int port, uS::TLS::Context sslContext, int options, uS::NodeData *nodeData, void *user) {
         addrinfo hints, *result;
         memset(&hints, 0, sizeof(addrinfo));
 
@@ -166,7 +166,7 @@ public:
         hints.ai_family = AF_UNSPEC;
         hints.ai_socktype = SOCK_STREAM;
 
-        if (getaddrinfo(nullptr, std::to_string(port).c_str(), &hints, &result)) {
+        if (getaddrinfo(host, std::to_string(port).c_str(), &hints, &result)) {
             return true;
         }
 


### PR DESCRIPTION
It should be possible to explicitly specify the address to bind to instead of just listening on all interfaces.

This change adds a "host" argument to `Hub::listen` which gets passed to `getaddrinfo()` in `Node.h` while preserving API compatibility.