### PR TITLE
allocate loop structure on cache line boundary.

### DIFF
--- a/src/uUV.cpp
+++ b/src/uUV.cpp
@@ -50,7 +50,7 @@ uv_loop_t *uv_handle_t::get_loop() const {
 }
 
 inline uv_loop_t *uv_loop_helper() {
-    uv_loop_t *loop = new uv_loop_t;
+    uv_loop_t *loop = new (aligned_alloc(64, sizeof(uv_loop_t))) uv_loop_t;
     loop->efd = epoll_create(1);
     loop->index = loopHead++;
     loop->numEvents = 0;


### PR DESCRIPTION
Allocate loop struct on cache line boundary. This together with #476 will make the entire structure to fit and be aligned on 3 cache lines (3 x 64 bytes).