### PR TITLE
Filter WebSocket connections before open

### DIFF
--- a/src/Group.cpp
+++ b/src/Group.cpp
@@ -233,7 +233,7 @@ void Group<isServer>::onCancelledHttpRequest(std::function<void (HttpResponse *)
 }
 
 template <bool isServer>
-void Group<isServer>::onHttpUpgrade(std::function<void(HttpSocket<isServer>, HttpRequest)> handler) {
+void Group<isServer>::onHttpUpgrade(std::function<bool(HttpSocket<isServer>, HttpRequest)> handler) {
     httpUpgradeHandler = handler;
 }
 

--- a/src/Group.h
+++ b/src/Group.h
@@ -26,7 +26,7 @@ struct WIN32_EXPORT Group : uS::NodeData {
     std::function<void(HttpResponse *)> httpCancelledRequestHandler;
 
     std::function<void(HttpSocket<isServer>)> httpDisconnectionHandler;
-    std::function<void(HttpSocket<isServer>, HttpRequest)> httpUpgradeHandler;
+    std::function<bool(HttpSocket<isServer>, HttpRequest)> httpUpgradeHandler;
 
     using errorType = typename std::conditional<isServer, int, void *>::type;
     std::function<void(errorType)> errorHandler;
@@ -71,7 +71,7 @@ public:
     void onHttpData(std::function<void(HttpResponse *, char *data, size_t length, size_t remainingBytes)> handler);
     void onHttpDisconnection(std::function<void(HttpSocket<isServer>)> handler);
     void onCancelledHttpRequest(std::function<void(HttpResponse *)> handler);
-    void onHttpUpgrade(std::function<void(HttpSocket<isServer>, HttpRequest)> handler);
+    void onHttpUpgrade(std::function<bool(HttpSocket<isServer>, HttpRequest)> handler);
 
 
     void broadcast(const char *message, size_t length, OpCode opCode);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -904,7 +904,7 @@ void serveEventSource() {
 
     // terminate any upgrade attempt, this is http only
     h.onHttpUpgrade([](uWS::HttpSocket<uWS::SERVER> s, uWS::HttpRequest req) {
-        s.terminate();
+        return false;
     });
 
     // httpRequest borde vara defaultsatt till att hantera upgrades, ta bort onupgrade! (sätter man request avsätts upgrade handlern)


### PR DESCRIPTION
Simple usage:

```c++
h.onHttpUpgrade([](uWS::HttpSocket<uWS::SERVER> s, uWS::HttpRequest req) {
    return false;
});
```

In this example WebSocket connections are not allowed.
If you provide no `httpUpgradeHandler` the connections are allowed by default.

Yep, `s.terminate()` would do the same. But consider this example:

```c++
h.onHttpUpgrade([](uWS::HttpSocket<uWS::SERVER> s, uWS::HttpRequest req) {
    return req.getHeader("origin").toString() == "http://example.com";
});
```

If the [`Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) isn't `http://example.com`, connection is rejected.
Why this is better than checking it after the connetion is open? Because instead of adding it to the pool and removing it, we can close it before.

FYI, I didn't know how to name this feature properly, feel free to change it.