### PR TITLE
Timer bug

### DIFF
--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -72,16 +72,16 @@ struct Timer {
     }
 
     void start(void (*cb)(Timer *), int timeout, int repeat) {
-		loop->timepoint = std::chrono::system_clock::now();
+        loop->timepoint = std::chrono::system_clock::now();
         std::chrono::system_clock::time_point timepoint = loop->timepoint + std::chrono::milliseconds(timeout);
 
-		Timepoint t = {cb, this, timepoint, repeat};
-		loop->timers.insert(
-			std::upper_bound(loop->timers.begin(), loop->timers.end(), t, [](const Timepoint &a, const Timepoint &b) {
-				return a.timepoint < b.timepoint;
-			}),
-			t
-		);
+        Timepoint t = {cb, this, timepoint, repeat};
+        loop->timers.insert(
+            std::upper_bound(loop->timers.begin(), loop->timers.end(), t, [](const Timepoint &a, const Timepoint &b) {
+                return a.timepoint < b.timepoint;
+            }),
+            t
+        );
 
         loop->delay = -1;
         if (loop->timers.size()) {

--- a/src/Epoll.h
+++ b/src/Epoll.h
@@ -72,14 +72,16 @@ struct Timer {
     }
 
     void start(void (*cb)(Timer *), int timeout, int repeat) {
+		loop->timepoint = std::chrono::system_clock::now();
         std::chrono::system_clock::time_point timepoint = loop->timepoint + std::chrono::milliseconds(timeout);
-        loop->timers.push_back({cb, this, timepoint, repeat});
-        std::sort(loop->timers.begin(), loop->timers.end(), [](const Timepoint &a, const Timepoint &b) {
-            return a.timepoint < b.timepoint;
-        });
 
-        // insertion sort
-
+		Timepoint t = {cb, this, timepoint, repeat};
+		loop->timers.insert(
+			std::upper_bound(loop->timers.begin(), loop->timers.end(), t, [](const Timepoint &a, const Timepoint &b) {
+				return a.timepoint < b.timepoint;
+			}),
+			t
+		);
 
         loop->delay = -1;
         if (loop->timers.size()) {


### PR DESCRIPTION
I was getting segfaults when using Timers in my own code, with very low repeat values. If an event loop iteration takes longer than a repeat value, the timer will have a timepoint in the past when it is re-added. This happens because loop->timepoint is not updated. So, I have fixed this by updating loop->timepoint in the Timer::start call.

While I was already here, I also put in the insertion sort.