### PR TITLE
clear pollQueue onEnd

### DIFF
--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -296,6 +296,8 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
         delete httpSocket->preAllocatedResponse;
     }
 
+    httpSocket->nodeData->changePollQueue.clear();
+
     if (!isServer) {
         httpSocket->cancelTimeout();
         Group<CLIENT>::from(httpSocket)->errorHandler(httpSocket->httpUser);

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -297,13 +297,10 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
     }
 
     httpSocket->nodeData->asyncMutex->lock();
-    auto end = httpSocket->nodeData->changePollQueue.end();
-    auto it = std::find_if(httpSocket->nodeData->changePollQueue.begin(), end, [=](Poll* s) {
-        return (s == httpSocket);
-    });
-    if (it != end) {
-        httpSocket->nodeData->changePollQueue.erase(it);
-    }
+    httpSocket->nodeData->changePollQueue.erase(
+        std::remove(httpSocket->nodeData->changePollQueue.begin(), httpSocket->nodeData->changePollQueue.end(), httpSocket),
+        httpSocket->nodeData->changePollQueue.end()
+    );
     httpSocket->nodeData->asyncMutex->unlock();
 
     if (!isServer) {

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -296,7 +296,13 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
         delete httpSocket->preAllocatedResponse;
     }
 
-    httpSocket->nodeData->changePollQueue.clear();
+    auto end = httpSocket->nodeData->changePollQueue.end();
+    auto it = std::find_if(httpSocket->nodeData->changePollQueue.begin(), end, [=](Poll* s) {
+        return (s == httpSocket);
+    });
+    if (it != end) {
+        httpSocket->nodeData->changePollQueue.erase(it);
+    }
 
     if (!isServer) {
         httpSocket->cancelTimeout();

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -296,6 +296,7 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
         delete httpSocket->preAllocatedResponse;
     }
 
+    httpSocket->nodeData->asyncMutex->lock();
     auto end = httpSocket->nodeData->changePollQueue.end();
     auto it = std::find_if(httpSocket->nodeData->changePollQueue.begin(), end, [=](Poll* s) {
         return (s == httpSocket);
@@ -303,6 +304,7 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
     if (it != end) {
         httpSocket->nodeData->changePollQueue.erase(it);
     }
+    httpSocket->nodeData->asyncMutex->unlock();
 
     if (!isServer) {
         httpSocket->cancelTimeout();

--- a/src/HTTPSocket.cpp
+++ b/src/HTTPSocket.cpp
@@ -296,12 +296,7 @@ void HttpSocket<isServer>::onEnd(uS::Socket *s) {
         delete httpSocket->preAllocatedResponse;
     }
 
-    httpSocket->nodeData->asyncMutex->lock();
-    httpSocket->nodeData->changePollQueue.erase(
-        std::remove(httpSocket->nodeData->changePollQueue.begin(), httpSocket->nodeData->changePollQueue.end(), httpSocket),
-        httpSocket->nodeData->changePollQueue.end()
-    );
-    httpSocket->nodeData->asyncMutex->unlock();
+    httpSocket->nodeData->clearPendingPollChanges(httpSocket);
 
     if (!isServer) {
         httpSocket->cancelTimeout();

--- a/src/Networking.h
+++ b/src/Networking.h
@@ -243,6 +243,15 @@ public:
         async->setData(this);
         async->start(NodeData::asyncCallback);
     }
+
+    void clearPendingPollChanges(Poll *p) {
+        asyncMutex->lock();
+        changePollQueue.erase(
+            std::remove(changePollQueue.begin(), changePollQueue.end(), p),
+            changePollQueue.end()
+        );
+        asyncMutex->unlock();
+    }
 };
 
 }

--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -288,6 +288,8 @@ void WebSocket<isServer>::onEnd(uS::Socket *s) {
         }
         webSocket->messageQueue.pop();
     }
+
+    webSocket->nodeData->clearPendingPollChanges(webSocket);
 }
 
 template <bool isServer>


### PR DESCRIPTION
I'm using the libuv backend, and get an assertion fail from libuv. I'm testing my server for handling aborted transfers. To test this, I telnet onto the web-server, request a file and exit the telnet session. The server has a breakpoint set early during processing of the HTTP request, and resumes execution after I've closed the telnet session.

The server will call `changePoll(this);` in Socket.h on line 343, which later causes libuv to fail with the following assertion:
libuv/src/unix/poll.c:105: uv_poll_start: Assertion `!uv__is_closing(handle)' failed.