### PR TITLE
Check error properly

### DIFF
--- a/src/Node.h
+++ b/src/Node.h
@@ -103,7 +103,7 @@ public:
             return nullptr;
         }
 
-        if (::connect(fd, result->ai_addr, result->ai_addrlen) == -1) {
+        if (::connect(fd, result->ai_addr, result->ai_addrlen)) {
             freeaddrinfo(result);
             return nullptr;
         }

--- a/src/Node.h
+++ b/src/Node.h
@@ -103,7 +103,11 @@ public:
             return nullptr;
         }
 
-        ::connect(fd, result->ai_addr, result->ai_addrlen);
+        if (::connect(fd, result->ai_addr, result->ai_addrlen) == -1) {
+            freeaddrinfo(result);
+            return nullptr;
+        }
+
         freeaddrinfo(result);
 
         SSL *ssl = nullptr;

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -260,7 +260,7 @@ protected:
             int length = recv(socket->getFd(), nodeData->recvBuffer, nodeData->recvLength, 0);
             if (length > 0) {
                 STATE::onData((Socket *) p, nodeData->recvBuffer, length);
-            } else if (length <= 0 || (length == SOCKET_ERROR && !netContext->wouldBlock())) {
+            } else if (length == 0 || (length == SOCKET_ERROR && !netContext->wouldBlock())) {
                 STATE::onEnd((Socket *) p);
             }
         }

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -260,7 +260,7 @@ protected:
             int length = recv(socket->getFd(), nodeData->recvBuffer, nodeData->recvLength, 0);
             if (length > 0) {
                 STATE::onData((Socket *) p, nodeData->recvBuffer, length);
-            } else if (length == 0 || (length == SOCKET_ERROR && !netContext->wouldBlock())) {
+            } else if (!length || (length == SOCKET_ERROR && !netContext->wouldBlock())) {
                 STATE::onEnd((Socket *) p);
             }
         }


### PR DESCRIPTION
This pull request contain following modifications:
* Handling ::connect error
* Checking return value from recv function properly

There are some issues reported by static analysis tool. But I am not sure that they should be fixed or not.
1. Error from setsockopt is not handled.
2. NodeData and Socket have derived classes, but they don't contain a virtual destructor.